### PR TITLE
Fix docs workflow missing nimdoc assets

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,11 +17,7 @@ jobs:
       - name: Restore nimdoc assets
         run: |
           mkdir -p "$HOME/.nimby/nim/doc"
-          mkdir -p "$HOME/.nimby/nim/tools/dochack"
           curl -fsSL "https://nim-lang.org/docs/nimdoc.out.css?v=2.2.8" -o "$HOME/.nimby/nim/doc/nimdoc.css"
-          curl -fsSL "https://nim-lang.org/docs/dochack.js" -o "$HOME/.nimby/nim/doc/dochack.js"
-          curl -fsSL "https://raw.githubusercontent.com/nim-lang/Nim/v2.2.8/tools/dochack/dochack.nim" -o "$HOME/.nimby/nim/tools/dochack/dochack.nim"
-          curl -fsSL "https://raw.githubusercontent.com/nim-lang/Nim/v2.2.8/tools/dochack/fuzzysearch.nim" -o "$HOME/.nimby/nim/tools/dochack/fuzzysearch.nim"
       - run: nim doc --index:on --project --git.url:https://github.com/${{ github.repository }} --git.commit:master  --out:${{ env.deploy-dir }} ${{ env.nim-src }}
       - name: "Copy to index.html"
         run: cp ${{ env.deploy-dir }}/${{ github.event.repository.name }}.html ${{ env.deploy-dir }}/index.html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,9 +18,11 @@ jobs:
         run: |
           mkdir -p "$HOME/.nimby/nim/doc"
           mkdir -p "$HOME/.nimby/nim/tools/dochack"
+          mkdir -p "$HOME/.nimby/nim/lib/pure"
           curl -fsSL "https://nim-lang.org/docs/nimdoc.out.css?v=2.2.8" -o "$HOME/.nimby/nim/doc/nimdoc.css"
           curl -fsSL "https://nim-lang.org/docs/dochack.js" -o "$HOME/.nimby/nim/doc/dochack.js"
           curl -fsSL "https://raw.githubusercontent.com/nim-lang/Nim/v2.2.8/tools/dochack/dochack.nim" -o "$HOME/.nimby/nim/tools/dochack/dochack.nim"
+          curl -fsSL "https://raw.githubusercontent.com/nim-lang/Nim/v2.2.8/lib/pure/fuzzysearch.nim" -o "$HOME/.nimby/nim/lib/pure/fuzzysearch.nim"
       - run: nim doc --index:on --project --git.url:https://github.com/${{ github.repository }} --git.commit:master  --out:${{ env.deploy-dir }} ${{ env.nim-src }}
       - name: "Copy to index.html"
         run: cp ${{ env.deploy-dir }}/${{ github.event.repository.name }}.html ${{ env.deploy-dir }}/index.html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,10 @@ jobs:
       - name: Restore nimdoc assets
         run: |
           mkdir -p "$HOME/.nimby/nim/doc"
+          mkdir -p "$HOME/.nimby/nim/tools/dochack"
           curl -fsSL "https://nim-lang.org/docs/nimdoc.out.css?v=2.2.8" -o "$HOME/.nimby/nim/doc/nimdoc.css"
+          curl -fsSL "https://raw.githubusercontent.com/nim-lang/Nim/v2.2.8/tools/dochack/dochack.nim" -o "$HOME/.nimby/nim/tools/dochack/dochack.nim"
+          curl -fsSL "https://raw.githubusercontent.com/nim-lang/Nim/v2.2.8/tools/dochack/fuzzysearch.nim" -o "$HOME/.nimby/nim/tools/dochack/fuzzysearch.nim"
       - run: nim doc --index:on --project --git.url:https://github.com/${{ github.repository }} --git.commit:master  --out:${{ env.deploy-dir }} ${{ env.nim-src }}
       - name: "Copy to index.html"
         run: cp ${{ env.deploy-dir }}/${{ github.event.repository.name }}.html ${{ env.deploy-dir }}/index.html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,8 +17,10 @@ jobs:
       - name: Restore nimdoc assets
         run: |
           mkdir -p "$HOME/.nimby/nim/doc"
+          mkdir -p "$HOME/.nimby/nim/tools/dochack"
           curl -fsSL "https://nim-lang.org/docs/nimdoc.out.css?v=2.2.8" -o "$HOME/.nimby/nim/doc/nimdoc.css"
           curl -fsSL "https://nim-lang.org/docs/dochack.js" -o "$HOME/.nimby/nim/doc/dochack.js"
+          curl -fsSL "https://raw.githubusercontent.com/nim-lang/Nim/v2.2.8/tools/dochack/dochack.nim" -o "$HOME/.nimby/nim/tools/dochack/dochack.nim"
       - run: nim doc --index:on --project --git.url:https://github.com/${{ github.repository }} --git.commit:master  --out:${{ env.deploy-dir }} ${{ env.nim-src }}
       - name: "Copy to index.html"
         run: cp ${{ env.deploy-dir }}/${{ github.event.repository.name }}.html ${{ env.deploy-dir }}/index.html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,11 @@ jobs:
       - uses: actions/checkout@v5
       - uses: treeform/setup-nim-action@v6
       - run: nimby install -g vmath
+      - name: Restore nimdoc assets
+        run: |
+          mkdir -p "$HOME/.nimby/nim/doc"
+          curl -fsSL "https://nim-lang.org/docs/nimdoc.out.css?v=2.2.8" -o "$HOME/.nimby/nim/doc/nimdoc.css"
+          curl -fsSL "https://nim-lang.org/docs/dochack.js" -o "$HOME/.nimby/nim/doc/dochack.js"
       - run: nim doc --index:on --project --git.url:https://github.com/${{ github.repository }} --git.commit:master  --out:${{ env.deploy-dir }} ${{ env.nim-src }}
       - name: "Copy to index.html"
         run: cp ${{ env.deploy-dir }}/${{ github.event.repository.name }}.html ${{ env.deploy-dir }}/index.html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,11 +18,10 @@ jobs:
         run: |
           mkdir -p "$HOME/.nimby/nim/doc"
           mkdir -p "$HOME/.nimby/nim/tools/dochack"
-          mkdir -p "$HOME/.nimby/nim/lib/pure"
           curl -fsSL "https://nim-lang.org/docs/nimdoc.out.css?v=2.2.8" -o "$HOME/.nimby/nim/doc/nimdoc.css"
           curl -fsSL "https://nim-lang.org/docs/dochack.js" -o "$HOME/.nimby/nim/doc/dochack.js"
           curl -fsSL "https://raw.githubusercontent.com/nim-lang/Nim/v2.2.8/tools/dochack/dochack.nim" -o "$HOME/.nimby/nim/tools/dochack/dochack.nim"
-          curl -fsSL "https://raw.githubusercontent.com/nim-lang/Nim/v2.2.8/lib/pure/fuzzysearch.nim" -o "$HOME/.nimby/nim/lib/pure/fuzzysearch.nim"
+          curl -fsSL "https://raw.githubusercontent.com/nim-lang/Nim/v2.2.8/tools/dochack/fuzzysearch.nim" -o "$HOME/.nimby/nim/tools/dochack/fuzzysearch.nim"
       - run: nim doc --index:on --project --git.url:https://github.com/${{ github.repository }} --git.commit:master  --out:${{ env.deploy-dir }} ${{ env.nim-src }}
       - name: "Copy to index.html"
         run: cp ${{ env.deploy-dir }}/${{ github.event.repository.name }}.html ${{ env.deploy-dir }}/index.html


### PR DESCRIPTION
## Summary
- Restore missing nimdoc runtime assets in docs CI with curl.
- Download nimdoc.out.css (versioned URL) and dochack.js into the Nim doc directory before running nim doc.

## Test plan
- [x] Manually run docs workflow via workflow_dispatch on DocFix.
- [x] Verify docs job completes successfully.